### PR TITLE
Fix "Controller not found" error by improving routing logic

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,8 +5,19 @@ require_once __DIR__ . '/../models/Ticket.php';
 require_once __DIR__ . '/../models/Attachment.php';
 require_once __DIR__ . '/../controllers/TicketController.php';
 
-$uri = explode('/', trim($_SERVER['REQUEST_URI'], '/'));
-$controllerName = ucfirst($uri[0] ?? 'tickets') . 'Controller';
+// Determine the base path dynamically
+$basePath = str_replace('/index.php', '', $_SERVER['SCRIPT_NAME']);
+
+// Get the request URI and remove the base path to get the route
+$requestUri = strtok($_SERVER['REQUEST_URI'], '?');
+$routePath = substr($requestUri, strlen($basePath));
+
+// Parse the route
+$uri = explode('/', trim($routePath, '/'));
+
+// Determine controller, method, and param
+$controllerSegment = !empty($uri[0]) ? $uri[0] : 'ticket';
+$controllerName = ucfirst($controllerSegment) . 'Controller';
 $method = $uri[1] ?? 'index';
 $param = $uri[2] ?? null;
 


### PR DESCRIPTION
The application was failing with a "Controller not found" error when deployed to a subdirectory because the routing logic did not account for the base path of the application.

This commit fixes the issue by:
1.  Dynamically calculating the application's base path.
2.  Stripping the base path from the request URI before parsing the route.
3.  Correcting the default controller name to 'ticket' (singular) to match the existing TicketController.
4.  Gracefully handling empty URI segments to fall back to the default controller.

These changes make the routing logic more robust and allow the application to work correctly when installed in a subdirectory.